### PR TITLE
fix: Correct retry logic in SearchFragment and a ViewModel bug

### DIFF
--- a/app/src/main/java/com/example/recipeapp/ui/search/SearchFragment.kt
+++ b/app/src/main/java/com/example/recipeapp/ui/search/SearchFragment.kt
@@ -84,7 +84,11 @@ class SearchFragment : Fragment() {
         val noInternetBinding = binding.noInternetView
 
         noInternetBinding.btnRetry.setOnClickListener {
-            viewModel.getCategories()
+            val currentQuery = binding.etSearchBox.text.toString()
+
+            if (currentQuery.isNotEmpty()) {
+                viewModel.searchMeals(currentQuery)
+            }
         }
 
         noInternetBinding.tvOpenSaved.setOnClickListener {

--- a/app/src/main/java/com/example/recipeapp/ui/viewmodels/HomeViewModel.kt
+++ b/app/src/main/java/com/example/recipeapp/ui/viewmodels/HomeViewModel.kt
@@ -81,7 +81,7 @@ class HomeViewModel(private val repository: MealRepository) : ViewModel() {
                     is java.net.UnknownHostException, is java.io.IOException -> "NO_INTERNET_CONNECTION"
                     else -> e.message ?: "An unknown error occurred"
                 }
-                searchedMeals.postValue(Resource.Error(errorMessage))
+                mealsByCategory.postValue(Resource.Error(errorMessage))
             }
         }
     }


### PR DESCRIPTION
This commit addresses two issues:

1.  In `SearchFragment`, the "Retry" button on the no-internet view was incorrectly calling `viewModel.getCategories()`. This has been corrected to call `viewModel.searchMeals()` with the current query, ensuring that the search is re-executed when connectivity is restored.

2.  In `HomeViewModel`, fixed a bug where the catch block for `getMealsByCategory()` was erroneously posting error states to the `searchedMeals` LiveData instead of `mealsByCategory`.